### PR TITLE
Allowed hosts & install psycopg

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -21,7 +21,7 @@ SECRET_KEY = SECRET_KEY
 
 DEBUG = DEBUG
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['api-gateway', 'localhost']
 
 
 # Application definition

--- a/config/settings.py
+++ b/config/settings.py
@@ -21,7 +21,7 @@ SECRET_KEY = SECRET_KEY
 
 DEBUG = DEBUG
 
-ALLOWED_HOSTS = ['api-gateway', 'localhost']
+# ALLOWED_HOSTS = ['api-gateway', 'localhost']
 
 
 # Application definition

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ constantly==23.10.4
 cryptography==43.0.3
 daphne==4.1.2
 Django==5.1.4
+django-cors-headers==4.6.0
 djangorestframework==3.15.2
 exceptiongroup==1.2.2
 frozenlist==1.5.0
@@ -34,6 +35,7 @@ packaging==24.2
 pip-tools==7.4.1
 pluggy==1.5.0
 propcache==0.2.1
+psycopg==3.2.3
 pyasn1==0.6.1
 pyasn1_modules==0.4.1
 pycparser==2.22


### PR DESCRIPTION
## 주요 구현 사항
- 전체 연결 중 필요한 패키지 설치
- allowed hosts 설정: api-gateway와 localhost의 요청만 허용하게